### PR TITLE
Remove @internal annotation from EmojiText

### DIFF
--- a/src/EmojiText.php
+++ b/src/EmojiText.php
@@ -5,9 +5,6 @@ namespace Astrotomic\Twemoji;
 use Astrotomic\Twemoji\Concerns\Configurable;
 use Closure;
 
-/**
- * @internal
- */
 class EmojiText
 {
     use Configurable;


### PR DESCRIPTION
EmojiText is used by comsumers of this library and thus is not an "internal" part of the library.

Fixes #7 