### PR TITLE
Fix PHP 8.1 deprecation errors

### DIFF
--- a/src/Twemoji.php
+++ b/src/Twemoji.php
@@ -25,7 +25,7 @@ class Twemoji implements JsonSerializable
 
     public static function emoji(string $emoji): self
     {
-        $chars = preg_split('//u', $emoji, null, PREG_SPLIT_NO_EMPTY);
+        $chars = preg_split('//u', $emoji, -1, PREG_SPLIT_NO_EMPTY);
 
         $codepoints = array_map(
             fn (string $code): string => dechex(mb_ord($code)),
@@ -53,6 +53,7 @@ class Twemoji implements JsonSerializable
         );
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->url();

--- a/src/Twemoji.php
+++ b/src/Twemoji.php
@@ -16,7 +16,7 @@ class Twemoji implements JsonSerializable
     protected array $codepoints;
 
     /**
-     * @param string[] $codepoints
+     * @param  string[]  $codepoints
      */
     public function __construct(array $codepoints)
     {


### PR DESCRIPTION
> preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in vendor/astrotomic/php-twemoji/src/Twemoji.php on line 28

> Return type of Astrotomic\Twemoji\Twemoji::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/astrotomic/php-twemoji/src/Twemoji.php on line 61