### PR TITLE
Update default base URL to jsdelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ You can use the `Twemoji::emoji()` method to get the Twemoji image URL for a sin
 use Astrotomic\Twemoji\Twemoji;
 
 Twemoji::emoji('🎉')->url();
-// https://twemoji.maxcdn.com/v/latest/svg/1f389.svg
+// https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f389.svg
 
 Twemoji::emoji('🎉')->png()->url();
-// https://twemoji.maxcdn.com/v/latest/72x72/1f389.png
+// https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/72x72/1f389.png
 
 Twemoji::emoji('🎉')->base('https://twemoji.astrotomic.info')->url();
 // https://twemoji.astrotomic.info/svg/1f389.svg
@@ -47,10 +47,10 @@ This isn't aware of emojis in attributes or anything - it just finds and replace
 use Astrotomic\Twemoji\Twemoji;
 
 Twemoji::text("Hello 👋🏿")->toMarkdown();
-// Hello ![👋🏿](https://twemoji.maxcdn.com/v/latest/svg/1f44b-1f3ff.svg)
+// Hello ![👋🏿](https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f44b-1f3ff.svg)
 
 Twemoji::text("Hello 👋🏿")->png()->toMarkdown();
-// Hello ![👋🏿](https://twemoji.maxcdn.com/v/latest/72x72/1f44b-1f3ff.png)
+// Hello ![👋🏿](https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/72x72/1f44b-1f3ff.png)
 ```
 
 In case you want to configure the replacer once and bind it to your container for example you can do that as well.
@@ -61,14 +61,14 @@ use Astrotomic\Twemoji\Replacer;
 $replacer = (new Replacer())->png();
 
 $replacer->text("Hello 👋🏿")->toMarkdown();
-// Hello ![👋🏿](https://twemoji.maxcdn.com/v/latest/72x72/1f44b-1f3ff.png)
+// Hello ![👋🏿](https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/72x72/1f44b-1f3ff.png)
 ```
 
 You can also override the replacer configuration for the specific replace operation without altering the replacer configuration.
 
 ```php
 $replacer->text("Hello 👋🏿")->svg()->toMarkdown();
-// Hello ![👋🏿](https://twemoji.maxcdn.com/v/latest/svg/1f44b-1f3ff.svg)
+// Hello ![👋🏿](https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/1f44b-1f3ff.svg)
 ```
 
 ## Testing

--- a/src/Concerns/Configurable.php
+++ b/src/Concerns/Configurable.php
@@ -8,7 +8,7 @@ trait Configurable
 {
     protected string $type = Twemoji::SVG;
 
-    protected string $base = 'https://twemoji.maxcdn.com/v/latest';
+    protected string $base = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets';
 
     public function base(string $base): self
     {

--- a/tests/Unit/TwemojiTest.php
+++ b/tests/Unit/TwemojiTest.php
@@ -7,35 +7,35 @@ use function Spatie\Snapshots\assertMatchesTextSnapshot;
 
 it('can generate url', function (string $emoji, string $twemoji) {
     assertEquals(
-        sprintf('https://twemoji.maxcdn.com/v/latest/svg/%s.svg', $twemoji),
+        sprintf('https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/%s.svg', $twemoji),
         Twemoji::emoji($emoji)->url()
     );
 })->with('emojis');
 
 it('can generate SVG url', function (string $emoji, string $twemoji) {
     assertEquals(
-        sprintf('https://twemoji.maxcdn.com/v/latest/svg/%s.svg', $twemoji),
+        sprintf('https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/%s.svg', $twemoji),
         Twemoji::emoji($emoji)->svg()->url()
     );
 })->with('emojis');
 
 it('can generate PNG url', function (string $emoji, string $twemoji) {
     assertEquals(
-        sprintf('https://twemoji.maxcdn.com/v/latest/72x72/%s.png', $twemoji),
+        sprintf('https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/72x72/%s.png', $twemoji),
         Twemoji::emoji($emoji)->png()->url()
     );
 })->with('emojis');
 
 it('can generate custom url', function (string $emoji, string $twemoji) {
     assertEquals(
-        sprintf('https://twemoji.astrotomic.info/svg/%s.svg', $twemoji),
+        sprintf('https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/%s.svg', $twemoji),
         Twemoji::emoji($emoji)->base('https://twemoji.astrotomic.info')->url()
     );
 })->with('emojis');
 
 it('can generate url from spatie/emoji', function (string $emoji) {
     assertMatchesRegularExpression(
-        '/^https:\/\/twemoji.maxcdn.com\/v\/latest\/svg\/([0-9a-f\-]+)\.svg$/',
+        '/^https:\/\/cdn.jsdelivr.net\/gh\/\/twitter\/twemoji\@latest\/assets\/svg\/([0-9a-f\-]+)\.svg$/',
         Twemoji::emoji($emoji)->url()
     );
 })->with('spatie-emojis');


### PR DESCRIPTION
Recently, maxcdn shut down - this library to not work since it used maxcdn as the default base URL.
The authors of an official twemoji fork [now suggest to use jsdelivr](https://github.com/twitter/twemoji/issues/580#issuecomment-1380685061).