### PR TITLE
Don't regenerate regexp string on every call

### DIFF
--- a/src/EmojiText.php
+++ b/src/EmojiText.php
@@ -10,6 +10,7 @@ class EmojiText
     use Configurable;
 
     protected string $text;
+    protected static ?string $regexp = null;
 
     public function __construct(string $text)
     {
@@ -66,6 +67,9 @@ class EmojiText
 
     protected function regexp(): string
     {
-        return '/'.file_get_contents(__DIR__.'/emoji_bytes.regexp').'/';
+        if (!static::$regexp) {
+            static::$regexp = '/'.file_get_contents(__DIR__.'/emoji_bytes.regexp').'/';
+        }
+        return static::$regexp;
     }
 }


### PR DESCRIPTION
As of current, `regexp()` in EmojiText creates a string from scratch on \*every single call*. Since the method is invoked on every replace call, it results in a massive performance penalty when doing a lot of replace operations. This PR makes it so the string gets initialized once and reused on subsequent calls, resulting in as much as a 5-6x speedup on my machine.

Below is a simple test case. I chose to perform 500k replacements to exacerbate the difference, but even in a real application context the difference was still quite pronounced doing as little as 5k replacements on short to moderate length strings.

```php
<?php

include __DIR__.'/vendor/autoload.php';

$et = new Astrotomic\Twemoji\EmojiText("Yo Angelo 🗿");

for ($i = 0; $i < 500000; $i++) {
    $et->toHtml();
}
```
Before the patch:
```
$ time php perf_test.php

real    0m9.726s
user    0m6.747s
sys     0m2.913s
```
After the patch:
```
$ time php perf_test.php

real    0m1.705s
user    0m1.695s
sys     0m0.010s
```